### PR TITLE
Change `EventHandler` implementation to handle events concurrently

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,5 +24,5 @@ plugins {
 
 subprojects {
     group = "com.github.jnnkmsr.event"
-    version = "0.1.2-alpha"
+    version = "0.1.3-alpha"
 }

--- a/event-compose/src/main/kotlin/com/github/jnnkmsr/event/compose/EventHandler.kt
+++ b/event-compose/src/main/kotlin/com/github/jnnkmsr/event/compose/EventHandler.kt
@@ -19,6 +19,13 @@ package com.github.jnnkmsr.event.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
 
 /**
  * [Launches][LaunchedEffect] a side effect that execute the given event
@@ -46,13 +53,57 @@ public fun <T> EventHandler(
     consumeFirst: Boolean = false,
     handler: suspend (content: T) -> Unit,
 ) {
-    LaunchedEffect(event) {
-        if (event as? UiEvent.Triggered != null) {
-            if (consumeFirst) onConsumed(event.consumed())
+    EventHandler(
+        Unit,
+        event = event,
+        onConsumed = onConsumed,
+        consumeImmediately = consumeFirst,
+        handler = handler
+    )
+}
 
-            handler(event.data)
+/**
+ * [Launches][LaunchedEffect] a side effect that execute the given event
+ * [handler] when the [event] becomes [Triggered][UiEvent.Triggered].
+ *
+ * @param keys Optional keys that will trigger the effect to be cancelled and
+ *   re-launched when the [EventHandler] is recomposed with any different keys.
+ * @param event The [UiEvent] triggering the effect whenever it becomes
+ *   non-`null` and [Triggered][UiEvent.Triggered].
+ * @param onConsumed Callback to be used to pass back any
+ *   [Consumed][UiEvent.Consumed] event from the effect. Depending on the value
+ *   of [consumeImmediately], the callback will be invoked before or after invoking
+ *   the event [handler].
+ * @param consumeImmediately Flag indicating whether [onConsumed] should be called
+ *   with the [Consumed][UiEvent.Consumed] event before (`true`) or after
+ *   (`false`) invoking the suspending event [handler]. Set this to `true` to
+ *   make sure the event will be consumed no matter if the [handler] ever
+ *   returns.
+ * @param handler The event handler receiving the [data][UiEvent.Triggered.data]
+ *   of the [Triggered][UiEvent.Triggered] event.
+ */
+@Composable
+@NonRestartableComposable
+public fun <T> EventHandler(
+    vararg keys: Any?,
+    event: UiEvent<T>?,
+    onConsumed: (consumed: UiEvent.Consumed) -> Unit,
+    consumeImmediately: Boolean = false,
+    handler: suspend (content: T) -> Unit,
+) {
+    val latestEvent by rememberUpdatedState(event)
+    val coroutineScope = rememberCoroutineScope()
 
-            if (!consumeFirst) onConsumed(event.consumed())
-        }
+    LaunchedEffect(*keys) {
+        snapshotFlow { latestEvent }
+            .filterNotNull()
+            .filterIsInstance<UiEvent.Triggered<T>>()
+            .collect { event ->
+                if (consumeImmediately) onConsumed(event.consumed())
+                coroutineScope.launch {
+                    handler(event.data)
+                    if (!consumeImmediately) onConsumed(event.consumed())
+                }
+            }
     }
 }


### PR DESCRIPTION
`EventHandler` now collects `UiEvent`s as a flow and launches handlers concurrently in separate coroutines instead of restarting the effect whenever there is a new event.